### PR TITLE
Preserves indentation behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ open up `Preferences > Key Bindings - user` and add this entry:
                 "operator": "equal", 
                 "match_all": true, 
                 "key": "selector"
+            },
+            {   
+                "key": "selection_empty", 
+                "operator": "equal", 
+                "operand": true,
+                "match_all": true 
             }
         ]
     }


### PR DESCRIPTION
This fix preserves the indent behaviour when multiple lines are selected without breaking abbreviation expansion.
